### PR TITLE
Honor actionbars 'enabled' config - fixes #3

### DIFF
--- a/modules/actionbars/core.lua
+++ b/modules/actionbars/core.lua
@@ -14,6 +14,7 @@ local c = {}
 --===============================================
 function mod:initialize()
 	c = mod:get_save()
+	if (not c.enabled) then mod.disabled = true; return end
 	
 	mod:remove_blizzard()
 


### PR DESCRIPTION
Check the 'enabled' option of the actionbars module during module initialize.

Fixed this locally, so thought I should share. If you don't accept pull requests no offence taken :)