### PR TITLE
Minimap button interactions

### DIFF
--- a/core/load.lua
+++ b/core/load.lua
@@ -42,22 +42,28 @@ loader:SetScript("OnEvent", function(self, event, addon)
 			local minimapIcon = LDB:NewDataObject("bdUI", {
 				type = "launcher",
 				icon = "Interface\\AddOns\\bdUI\\media\\minimapicon.blp",
-				OnClick = function(clickedframe, button)
-					if (IsControlKeyDown()) then
-						ReloadUI()
-					end
-					
+				OnClick = function(clickedframe, button)					
 					if (button == "LeftButton") then
-						bdUI.bdConfig:toggle()
+						if (IsControlKeyDown()) then
+							ReloadUI()
+						else
+							bdUI.bdConfig:toggle()
+						end
 					elseif (button == "RightButton") then
-						bdUI.bdConfig.header.lock:Click()
+						if (IsControlKeyDown()) then
+							BDUI_SAVE.MinimapIcon.hide = true
+							LDBIcon:Hide("bdUI")
+						else
+							bdUI.bdConfig.header.lock:Click()
+						end
 					end	
 				end,
 				OnTooltipShow = function(tt)
 					tt:AddLine(bdUI.colorString.."Config")
 					tt:AddLine("|cffFFAA33Left Click:|r |cff00FF00Open bdUI Config|r")
 					tt:AddLine("|cffFFAA33Right Click:|r |cff00FF00Toggle lock/unlock|r")
-					tt:AddLine("|cffFFAA33Ctrl+Click:|r |cff00FF00Reload UI|r")
+					tt:AddLine("|cffFFAA33Ctrl+Left Click:|r |cff00FF00Reload UI|r")
+					tt:AddLine("|cffFFAA33Ctrl+Right Click:|r |cff00FF00Hide Button|r")
 				end,
 			})
 

--- a/core/load.lua
+++ b/core/load.lua
@@ -38,11 +38,12 @@ loader:SetScript("OnEvent", function(self, event, addon)
 		-- icon
 		local LDB = LibStub("LibDataBroker-1.1", true)
 		local LDBIcon = LDB and LibStub("LibDBIcon-1.0", true)
+		bdUI_configButton = LDB and LibStub("LibDBIcon-1.0", true)
 		if LDB then
 			local minimapIcon = LDB:NewDataObject("bdUI", {
 				type = "launcher",
 				icon = "Interface\\AddOns\\bdUI\\media\\minimapicon.blp",
-				OnClick = function(clickedframe, button)					
+				OnClick = function(clickedframe, button)
 					if (button == "LeftButton") then
 						if (IsControlKeyDown()) then
 							ReloadUI()
@@ -51,8 +52,9 @@ loader:SetScript("OnEvent", function(self, event, addon)
 						end
 					elseif (button == "RightButton") then
 						if (IsControlKeyDown()) then
-							BDUI_SAVE.MinimapIcon.hide = true
-							LDBIcon:Hide("bdUI")
+							bdUI_configButton:Hide("bdUI")
+							BDUI_SAVE.MinimapIcon.hide = true --for non bdUI minimaps
+							bdUI:get_module("Maps").config.showconfig = false
 						else
 							bdUI.bdConfig.header.lock:Click()
 						end
@@ -67,12 +69,12 @@ loader:SetScript("OnEvent", function(self, event, addon)
 				end,
 			})
 
-			if LDBIcon then
+			if bdUI_configButton then
 				-- init value
 				if (BDUI_SAVE.MinimapIcon == nil) then
 					BDUI_SAVE.MinimapIcon = { minimapPos = 225, hide = false }
 				end
-				LDBIcon:Register("bdUI", minimapIcon, BDUI_SAVE.MinimapIcon)
+				bdUI_configButton:Register("bdUI", minimapIcon, BDUI_SAVE.MinimapIcon)
 			end
 		end
 

--- a/core/load.lua
+++ b/core/load.lua
@@ -62,6 +62,10 @@ loader:SetScript("OnEvent", function(self, event, addon)
 			})
 
 			if LDBIcon then
+				-- init value
+				if (BDUI_SAVE.MinimapIcon == nil) then
+					BDUI_SAVE.MinimapIcon = { minimapPos = 225, hide = false }
+				end
 				LDBIcon:Register("bdUI", minimapIcon, BDUI_SAVE.MinimapIcon)
 			end
 		end

--- a/modules/maps/elements/buttonframe.lua
+++ b/modules/maps/elements/buttonframe.lua
@@ -200,6 +200,16 @@ function mod:create_button_frame()
 		if (config.buttonpos == "Disabled") then return end
 		if (InCombatLockdown()) then return end
 
+		if (not config.showconfig) then
+			hideButtons['LibDBIcon10_bdUI'] = true
+			bdUI_configButton:Hide("bdUI")
+			BDUI_SAVE.MinimapIcon.hide = true
+		else
+			hideButtons['LibDBIcon10_bdUI'] = false
+			bdUI_configButton:Show("bdUI")
+			BDUI_SAVE.MinimapIcon.hide = false
+		end
+
 		if (config.hideclasshall) then
 			hideButtons['GarrisonLandingPageMinimapButton'] = true
 		else


### PR DESCRIPTION
Minimap button was not holding new positions and there was no way to disable it from the UI when not using the bdUI minimap. So, I added an interaction with the button to allow non-bdUI minimap users to remove it as well as default variables for the minimap state that so it holds the positions when moved.

I also added back some logic that you removed in 675b56688e369670444db537630c3cec7f032663 in order to update the display state when `show bdConfig Button` is toggled in the settings.

Unfortunately, I wasn't really sure how your settings callbacks work so my changes don't allow the icon to be re-enabled when not using the bdUI Minimap.