### PR TITLE
Implement toggle for titles in unit tooltips

### DIFF
--- a/modules/tooltips/core.lua
+++ b/modules/tooltips/core.lua
@@ -92,7 +92,13 @@ local function replace_tooltip_lines(self, unit)
 	if (not unit) then return end
 	
 	-- name info
-	local name, realm = UnitName(unit)
+	local _, realm = UnitName(unit)
+	local name = ""
+	if (mod.config.enabletitlesintt) then
+		name = UnitPVPName(unit) or UnitName(unit)
+	else
+		name = UnitName(unit)
+	end
 	local dnd = UnitIsAFK(unit) and " |cffAAAAAA<AFK>|r " or UnitIsDND(unit) and " |cffAAAAAA<DND>|r " or ""
 	self.namecolor = {mod:getUnitColor(unit)}
 	self.namehex = RGBPercToHex(unpack(self.namecolor))

--- a/modules/tooltips/init.lua
+++ b/modules/tooltips/init.lua
@@ -68,6 +68,19 @@ local config = {
 			}
 		}
 	},
+	{
+		key = "titles",
+		type = "group",
+		heading = "Titles",
+		args = {
+			{
+				key = "enabletitlesintt",
+				type = "toggle",
+				value = true,
+				label = "Enable title display in unit mouseover"
+			}
+		}
+	},
 	
 }
 


### PR DESCRIPTION
Doesn't close a specific issue, just allows the user to decide whether or not they want titles visible at no performance cost.