### PR TITLE
Fix ObjectiveTracker with disabled map module

### DIFF
--- a/modules/maps/core.lua
+++ b/modules/maps/core.lua
@@ -9,11 +9,10 @@ local config
 --=============================================
 function mod:initialize()
 	mod.config = mod:get_save()
-	
-	mod:create_objective_tracker()
 
 	if (not mod.config.enabled) then return end
 
+	mod:create_objective_tracker()
 	mod:create_minimap()
 	mod:create_button_frame()
 	mod:worldmap_coords()


### PR DESCRIPTION
I've returned to the game after long break and found out that my ObjectiveTracker is partially out of screen.

![objective-tracker-bug](https://user-images.githubusercontent.com/18231421/116583508-7bc10c80-a927-11eb-9363-814a5477718f.png)

After short investigation I determine the problem.

I am only using nameplates module and sometimes disabled modules perform unexpected changes.
This time it is `move_objective_tracker()` from `mod:create_objective_tracker()` in `objectivetracker.lua`.

My fix solves problem for me and I believe does not break anything for others.
