### PR TITLE
Fix Blizzard_TokenUI.lua error

### DIFF
--- a/modules/bags/core.lua
+++ b/modules/bags/core.lua
@@ -10,6 +10,12 @@ function mod:initialize()
 	mod.config = mod:get_save()
 
 	if (not mod.config.enabled) then return end
+
+	--============================================
+	-- allow for tracking beyond 3 currencies for /elements/currencies.lua
+	--============================================
+	MAX_WATCHED_TOKENS = 10
+	
 	mod.initialized = true
 	mod.border = bdUI:get_border(UIParent)
 

--- a/modules/bags/elements/currencies.lua
+++ b/modules/bags/elements/currencies.lua
@@ -4,11 +4,6 @@ local mod = bdUI:get_module("Bags")
 -- if bdUI:isClassicAny() then return end
 
 --============================================
--- allow for tracking beyond 3
---============================================
-MAX_WATCHED_TOKENS = 10
-
---============================================
 -- Currency object
 --============================================
 local currencies = {}


### PR DESCRIPTION
Fix #43.

Do not override global vars if module is not even enabled.

Blizzard code goes out of range by looping over MAX_WATCHED_TOKENS.