### PR TITLE
Update range.lua

### DIFF
--- a/modules/actionbars/elements/range.lua
+++ b/modules/actionbars/elements/range.lua
@@ -24,6 +24,7 @@ local function update_useable(self, checksRange, inRange)
 	end
 
 	local action = self.action
+	if (action == nil) then return end
 	local isUsable, notEnoughMana = IsUsableAction(action)
 	local colorkey = "normal"
 


### PR DESCRIPTION
add nil check to range check. encountered this on my pet bars in retail
```
Message: ...ce\AddOns\bdUI\modules\actionbars\elements\range.lua:27: Usage: IsUsableAction(slot)
Time: Sat Sep 24 11:04:05 2022
Count: 324
Stack: ...ce\AddOns\bdUI\modules\actionbars\elements\range.lua:27: Usage: IsUsableAction(slot)
[string "=[C]"]: in function `IsUsableAction'
[string "@Interface\AddOns\bdUI\modules\actionbars\elements\range.lua"]:27: in function <...ce\AddOns\bdUI\modules\actionbars\elements\range.lua:20>
[string "=(tail call)"]: ?
[string "@Interface\FrameXML\PetActionBarFrame.lua"]:144: in function <Interface\FrameXML\PetActionBarFrame.lua:112>

Locals: (*temporary) = nil
```